### PR TITLE
[TIDOC-1052] Updated YAML file reader and JSDuck renderer to display admin-required tag.

### DIFF
--- a/lib/jsduck/renderer.rb
+++ b/lib/jsduck/renderer.rb
@@ -281,6 +281,7 @@ module JsDuck
       owner = m[:owner]
       # is this method inherited from parent?
       inherited = (owner != @cls[:name])
+      adminRequired = m[:meta][:adminRequired]
 
       return [
         "<div id='#{m[:id]}' class='member #{first_child} #{inherited ? 'inherited' : 'not-inherited'}'>",
@@ -296,6 +297,7 @@ module JsDuck
             "</div>",
             # method params signature or property type signature
             render_signature(m),
+            adminRequired ? "<strong class='signature'>admin only</strong>" : "",
           "</div>",
           # short and long descriptions
           "<div class='description'>",
@@ -405,6 +407,7 @@ module JsDuck
       if @opts.rest
         optional = ""
         required = ' <strong class="required signature">required</strong>'
+        adminRequired = ' <strong class="signature">admin only</strong>'
       else
         optional = " (optional)"
         required = ""
@@ -414,6 +417,7 @@ module JsDuck
           "<span class='pre'>#{p[:name]}</span> : ",
           p[:html_type],
           p[:optional] ? optional : required,
+          p[:adminRequired] ? adminRequired : optional,
           p[:deprecated] ? '<strong class="deprecated signature">deprecated</strong>' : "",
           "<div class='sub-desc'>",
             p[:doc],

--- a/lib/jsduck/renderer.rb
+++ b/lib/jsduck/renderer.rb
@@ -297,7 +297,7 @@ module JsDuck
             "</div>",
             # method params signature or property type signature
             render_signature(m),
-            adminRequired ? "<strong class='signature'>admin only</strong>" : "",
+            adminRequired ? "<strong class='signature'>admin-only</strong>" : "",
           "</div>",
           # short and long descriptions
           "<div class='description'>",
@@ -407,7 +407,7 @@ module JsDuck
       if @opts.rest
         optional = ""
         required = ' <strong class="required signature">required</strong>'
-        adminRequired = ' <strong class="signature">admin only</strong>'
+        adminRequired = ' <strong class="signature">admin-only</strong>'
       else
         optional = " (optional)"
         required = ""

--- a/lib/jsduck/rest_file.rb
+++ b/lib/jsduck/rest_file.rb
@@ -104,7 +104,8 @@ module JsDuck
             :files => [ @fakefile ],
             :meta => {
                 :hide => false,
-                :loginRequired => false
+                :loginRequired => false,
+                :adminRequired => false
             },
             :url => "Error: No URL set for this method.",
             :httpMethod => "GET",
@@ -148,6 +149,8 @@ module JsDuck
                 methodHash[:url] = tag[1]
             elsif tag[0] == "login-required"
                 methodHash[:meta][:loginRequired] = tag[1]
+            elsif tag[0] == "admin-required"
+                methodHash[:meta][:adminRequired] = tag[1]
             end
         end
         methodHash
@@ -200,6 +203,9 @@ module JsDuck
             paramHash[:optional] = ! param["required"]
         else
             paramHash[:optional] = true
+        end
+        if param.has_key?("admin-required")
+            paramHash[:adminRequired] = param["admin-required"]
         end
         if param.has_key?("type")
             paramHash[:type] = convert_type(param["type"])


### PR DESCRIPTION
This adds an "admin only" badge to methods and method parameters that have the following YAML field:

```
admin-required: true
```
For example: 

* Admin-only method:
![image](https://cloud.githubusercontent.com/assets/408952/6319542/7cac12a0-ba8d-11e4-9034-5f9eaebfc38c.png)

* Admin-only method parameter:
![image](https://cloud.githubusercontent.com/assets/408952/6319511/bb071f14-ba8c-11e4-8736-2bd04e2509c7.png)

#### Verification steps

1. Merge in cloud_docs changes which adds more `admin-required` tags to methods and method parameters): https://github.com/appcelerator/cloud_docs/pull/197 .
2. Merge in new `adminRequiredTag` in doctools: https://github.com/appcelerator/doctools/pull/76.
3. Merge in this PR.
4. Run clouddeploy.sh and open dist/cloud/latest/index.html.
5. Spot check YAML methods and method params that have `admin-required: true` have the 'admin only' badge.