### PR TITLE
[TIDOC-2216] Add option to pass REST YAML files to be combined with JSDuck doc site

### DIFF
--- a/lib/jsduck/batch_parser.rb
+++ b/lib/jsduck/batch_parser.rb
@@ -28,6 +28,11 @@ module JsDuck
     # Parses the files and returns instance of Relations class.
     def run
       @parsed_files = parallel_parse(@opts.input_files)
+      if @opts.rest_files.length != 0
+        @opts.rest = true
+        @parsed_files.concat(parallel_parse(@opts.rest_files))
+        @opts.rest = false
+      end
       result = aggregate(@parsed_files)
       @relations = filter_classes(result)
       if ! @opts.rest

--- a/lib/jsduck/icons.rb
+++ b/lib/jsduck/icons.rb
@@ -14,7 +14,7 @@ module JsDuck
           :isObject => isObject(cls)
         })
         # TIDOC-1071 Modifications to support Cloud DocTree
-        if opts.rest
+        if defined? cls.rest
           cls[:members].each do |member|
             if member[:tagname].eql? :method and not(member[:deprecated])
               json.push({

--- a/lib/jsduck/lint.rb
+++ b/lib/jsduck/lint.rb
@@ -15,7 +15,7 @@ module JsDuck
     def run
       warn_no_doc
       warn_unnamed
-      warn_optional_params
+      #warn_optional_params
       warn_duplicate_params
       warn_duplicate_members
       warn_singleton_statics

--- a/lib/jsduck/options.rb
+++ b/lib/jsduck/options.rb
@@ -11,6 +11,7 @@ module JsDuck
   # Keeps command line options
   class Options
     attr_accessor :input_files
+    attr_accessor :rest_files
 
     attr_accessor :output_dir
     attr_accessor :ignore_global
@@ -61,6 +62,7 @@ module JsDuck
 
     def initialize
       @input_files = []
+      @rest_files = []
 
       @output_dir = nil
       @ignore_global = false
@@ -629,6 +631,19 @@ module JsDuck
           @rest = true
           # automatically disable source for YML input -- no source files to link to.
           @source = false
+        end
+
+        opts.on('--rest_files=FNAME', "", "") do |fname|
+          fname_pattern = "/**/*.{yml}"
+          if File.exists?(fname)
+            if File.directory?(fname)
+              Dir[fname+fname_pattern].each {|f| @rest_files << f }
+            else
+              @rest_files << fname
+            end
+          else
+            Logger.warn(nil, "File not found", fname)
+          end
         end
 
         opts.on('--stats',

--- a/lib/jsduck/renderer.rb
+++ b/lib/jsduck/renderer.rb
@@ -215,7 +215,7 @@ module JsDuck
     end
 
     def render_all_sections
-      properties = (@opts.rest && "Fields") || "Properties"
+      properties = (@cls.has_key?(:rest) && "Fields")  || "Properties"
       sections = [
         {:type => :property, :title => properties },
         {:type => :method, :title => "Methods"},
@@ -334,7 +334,7 @@ module JsDuck
 
       doc << render_params_and_return(m)
 
-      if @opts.rest
+      if @cls.has_key?(:rest)
           doc << render_examples(m)
       end
 
@@ -378,7 +378,7 @@ module JsDuck
         ]
       end
 
-      if @opts.rest
+      if @cls.has_key?(:rest)
         if item[:response] && item[:response].length > 0
           doc << '<h3 class="pa">Response Parameters</h3>'
           doc << [
@@ -405,7 +405,7 @@ module JsDuck
 
     def render_long_param(p)
       # for REST, default to optional parameters
-      if @opts.rest
+      if @cls.has_key?(:rest)
         optional = ""
         required = ' <strong class="required signature">required</strong>'
         adminRequired = ' <strong class="signature">admin-only</strong>'

--- a/lib/jsduck/rest_file.rb
+++ b/lib/jsduck/rest_file.rb
@@ -65,7 +65,8 @@ module JsDuck
                 :meta => {},
                 :aliases => {},
                 :files => [ @fakefile ],
-                :members => []
+                :members => [],
+                :rest => true
             }
             objects << @currentObject
         elsif item[0] == "description"

--- a/lib/jsduck/signature_renderer.rb
+++ b/lib/jsduck/signature_renderer.rb
@@ -15,7 +15,7 @@ module JsDuck
     def render(member)
       # Keep the code simpler by not passing around the member hash
       @m = member
-      if @opts.rest
+      if @cls.has_key?(:rest)
         return [
           render_rest,
           render_link,
@@ -67,7 +67,7 @@ module JsDuck
     def render_type
       if like_property?
         render_property_type
-      elsif ! @opts.rest && @m[:tagname] != :event
+      elsif ! @cls.has_key?(:rest) && @m[:tagname] != :event
         render_params + render_return
       end
     end

--- a/lib/jsduck/source/writer.rb
+++ b/lib/jsduck/source/writer.rb
@@ -17,6 +17,9 @@ module JsDuck
 
         FileUtils.mkdir(destination)
         Util::Parallel.each(@source_files) do |file|
+          if file.html_filename.nil?
+            next
+          end
           Logger.log("Writing source", file.html_filename)
           write_single(destination + "/" + file.html_filename, file.to_html)
         end
@@ -38,8 +41,10 @@ module JsDuck
             ci_name = name.downcase # case insensitive name
             i += 1
           end while filenames.has_key?(ci_name)
-          filenames[ci_name] = true
-          file.html_filename = name
+          if not name.include? ".yml"
+            filenames[ci_name] = true
+            file.html_filename = name
+          end
         end
       end
 
@@ -54,7 +59,9 @@ module JsDuck
       end
 
       def write_single(filename, source)
-        ::File.open(filename, 'w') {|f| f.write(wrap_page(source)) }
+        if not filename.nil?
+          ::File.open(filename, 'w') {|f| f.write(wrap_page(source)) }
+        end
       end
 
       # Returns source wrapped inside HTML page

--- a/template/app/view/cls/Overview.js
+++ b/template/app/view/cls/Overview.js
@@ -238,7 +238,8 @@ Ext.define('Docs.view.cls.Overview', {
 
         // Only show members who's name matches with the search string
         // and its type is currently visible
-        var re = new RegExp(Ext.String.escapeRegex(search), "i");
+        var re = new RegExp(Ext.String.escapeRegex(search), "i"),
+            currentContext = this;
         this.eachMember(function(m) {
 
             var name = m.name;
@@ -292,7 +293,7 @@ Ext.define('Docs.view.cls.Overview', {
 
             // For ACS REST and Alloy APIs, don't apply platform filtering, or if the platform filters are undefined.
             // Assuming if any one of the platform filters is undefined ('android' in this case), they're all undefined.
-            if (!Docs.isRESTDoc && (m.owner.indexOf("Alloy") == -1) && (show['android'] != undefined)) {
+            if (!currentContext.docClass.rest && (m.owner.indexOf("Alloy") == -1) && (show['android'] != undefined)) {
                 // Only show if the member- and class-specified platforms intersects with the platform filter selection.
                 var visible = !(
                     !show['public']    && !(m.meta['private'] || m.meta['protected']) ||

--- a/template/app/view/cls/Toolbar.js
+++ b/template/app/view/cls/Toolbar.js
@@ -63,7 +63,7 @@ Ext.define('Docs.view.cls.Toolbar', {
 
         var memberTitles = {
             cfg: "Configs",
-            property: (Docs.isRESTDoc ? "Fields" : "Properties"),
+            property: (this.docClass.rest ? "Fields" : "Properties"),
             method: "Methods",
             event: "Events",
             css_var: "CSS Vars",
@@ -236,9 +236,10 @@ Ext.define('Docs.view.cls.Toolbar', {
     showMenuItems: function(show, isSearch, re) {
         Ext.Array.forEach(['cfg', 'property', 'method', 'event'], function(type) {
             if (this.memberButtons[type]) {
-                var store = this.memberButtons[type].getStore();
+                var store = this.memberButtons[type].getStore(),
+                    currentContext = this;
                 store.filterBy(function(m) {
-                    if(!Docs.isRESTDoc && (show['android'] != undefined)) {
+                    if(!currentContext.docClass.rest && (show['android'] != undefined)) {
                         return !(
                             !show['public']    && !(m.get("meta")["private"] || m.get("meta")["protected"]) ||
                             !show['protected'] && m.get("meta")["protected"] ||
@@ -334,7 +335,7 @@ Ext.define('Docs.view.cls.Toolbar', {
 
     // Returns menu items to display in Filter menu based. If showing REST APIs, only show deprecated and removed.
     getMenuItems: function() {
-        if(!Docs.isRESTDoc) {
+        if(!this.docClass.rest) {
             return [
                 this.checkItems['android'],
                 this.checkItems['ipad'],                    


### PR DESCRIPTION
New `--rest_files` options to pass the cloud_doc YAML files to be intergrated with all the Appcelerator docs.

From doctools, execute:
~~~
ruby ../jsduck/bin/jsduck --template ../jsduck/template --config jsduck.config --output dist/ --rest_files ../cloud_docs/apidoc/ build/titanium.js 
~~~

Requires doctools and cloud_docs repo as well.  Place pre-built Titanium JSDuck file in doctools/build/titanium.js.


Caveats:

1. Had to disable the optional params checked in lint.rb.
2. Method tree for REST classes is not rendering.