### PR TITLE
fix: correct icon names for platform distributed icons

### DIFF
--- a/template/app/view/Tabs.js
+++ b/template/app/view/Tabs.js
@@ -70,7 +70,7 @@ Ext.define('Docs.view.Tabs', {
                     '<span class="icn {iconCls}">&nbsp;</span>',
                     '<a class="tabUrl main-tab" href="{href}">{text}</a>',
                 '</div>',
-            '<div class="r"><a class="icon-cancel close" href="#">&nbsp;</a></div>',
+            '<div class="r"><a class="platform-icon-cancel close" href="#">&nbsp;</a></div>',
             '</div>'
         );
 
@@ -180,10 +180,10 @@ Ext.define('Docs.view.Tabs', {
 
         switch(tab.iconCls) {
             case "icon-class":
-                tab.iconCls = 'icon-link';
+                tab.iconCls = 'platform-icon-link';
                 break;
             case "icon-guide":
-                tab.iconCls = 'icon-doc-text';
+                tab.iconCls = 'platform-icon-doc-text';
                 break;
             case "icon-video":
                 tab.iconCls = 'fa-video-camera';
@@ -213,7 +213,7 @@ Ext.define('Docs.view.Tabs', {
             var fullClsName = tab.href.replace(/^.*#!?\/api\//, "");
             tab.text = Docs.ClassRegistry.shortName(fullClsName);
             tab.tooltip = fullClsName;
-            tab.iconClass = 'icon-link';
+            tab.iconClass = 'platform-icon-link';
         }
         else {
             tab.tooltip = tab.text;

--- a/template/app/view/cls/Index.js
+++ b/template/app/view/cls/Index.js
@@ -69,6 +69,6 @@ Ext.define('Docs.view.cls.Index', {
      */
     getTab: function() {
         var enabled = (Docs.data.classes || []).length > 0;
-        return enabled ? {cls: 'classes', href: '#!/api', tooltip: 'API Documentation', iconClass: 'icon-cog'} : false;
+        return enabled ? {cls: 'classes', href: '#!/api', tooltip: 'API Documentation', iconClass: 'platform-icon-cog'} : false;
     }
 });

--- a/template/app/view/guides/Index.js
+++ b/template/app/view/guides/Index.js
@@ -47,7 +47,7 @@ Ext.define('Docs.view.guides.Index', {
      */
     getTab: function() {
         var enabled = (Docs.data.guides|| []).length > 0;
-        return enabled ? {cls: 'guides', href: '#!/guide', tooltip: 'Guides', iconClass: 'icon-doc-text'} : false;
+        return enabled ? {cls: 'guides', href: '#!/guide', tooltip: 'Guides', iconClass: 'platform-icon-doc-text'} : false;
     },
 
     /**

--- a/template/resources/codemirror/unified-nav-extras.js
+++ b/template/resources/codemirror/unified-nav-extras.js
@@ -224,20 +224,20 @@ var AppcDocsSite = {
 								api_name,
 								elem = {},
 								re,
-								icon = 'icon-link';
+								icon = 'platform-icon-link';
 
 							// Determine API type
 							if (doc.url.match(/\-method\-/g)) {
 								api_type = 'method';
-								icon = 'icon-cog';
+								icon = 'platform-icon-cog';
 							}
 							else if (doc.url.match(/\-event\-/g)) {
 								api_type = 'event';
-								icon = 'icon-flash';
+								icon = 'platform-icon-flash';
 							}
 							else if (doc.url.match(/\-property\-/g)) {
 								api_type = 'property';
-								icon = 'icon-menu';
+								icon = 'platform-icon-menu';
 							}
 
 							api_name = tokens[tokens.length - 1];
@@ -302,7 +302,7 @@ var AppcDocsSite = {
 		dropdown = document.getElementById('appc-docs-products');
 		dropdown.onclick = AppcDocsSite.displayMenu;
 
-		rightside[0].insertAdjacentHTML('afterbegin', '<span><div id="appc-docs-search"><i class="icon-search-1"></i><input type="text" id="appc-docs-search-form" placeholder="Search Docs"></input><i id="appc-docs-search-cancel" class="icon-cancel-1"></i></div><div id="appc-docs-search-results"/></span>');
+		rightside[0].insertAdjacentHTML('afterbegin', '<span><div id="appc-docs-search"><i class="platform-icon-search"></i><input type="text" id="appc-docs-search-form" placeholder="Search Docs"></input><i id="appc-docs-search-cancel" class="platform-icon-cancel"></i></div><div id="appc-docs-search-results"/></span>');
 		searchForm = document.getElementById('appc-docs-search-form');
 		searchForm.onkeyup = AppcDocsSite.delayedSearch;
 		searchForm.onblur = AppcDocsSite.dismissResults;


### PR DESCRIPTION
I believe this fixes most of the icons on the main view of the docs site that reference the platform iconset.

To do this, I did a search of the template dir using `rg icon- ./template/` and cross-referenced the results with the platform iconset so I believe it to be correct but I am unable to build the docs to fully verify